### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ git:
 language: node_js
 
 node_js:
-  - "0.10"
-  - "0.12"
-  - iojs
+  - 4
+  - 6
+  - 8
+  - 10
 
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Changelog
 
-## [0.0.1](https://github.com/ruimarinho/defaults-deep-safe/releases/tag/0.0.1) (2018-08-30)
+## [0.0.1](https://github.com/ruimarinho/defaults-deep-safe/releases/tag/0.0.1) (2018-09-12)
 - Update package version [\#1](https://github.com/ruimarinho/defaults-deep-safe/pull/1) ([fixe](https://github.com/fixe))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Changelog
+# Changelog
 
-### 0.0.1 / 2015-02-08
-- [#1](https://github.com/seegno/defaults-deep-safe/pull/1) Update package version (@fixe)
+## [0.0.1](https://github.com/ruimarinho/defaults-deep-safe/releases/tag/0.0.1) (2018-08-30)
+- Update package version [\#1](https://github.com/ruimarinho/defaults-deep-safe/pull/1) ([fixe](https://github.com/fixe))

--- a/README.md
+++ b/README.md
@@ -103,5 +103,5 @@ MIT
 
 [npm-image]: https://img.shields.io/npm/v/defaults-deep-safe.svg
 [npm-url]: https://npmjs.org/package/defaults-deep-safe
-[travis-image]: https://travis-ci.org/seegno/defaults-deep-safe.svg
-[travis-url]: https://travis-ci.org/seegno/defaults-deep-safe
+[travis-image]: https://travis-ci.org/ruimarinho/defaults-deep-safe.svg
+[travis-url]: https://travis-ci.org/ruimarinho/defaults-deep-safe

--- a/index.js
+++ b/index.js
@@ -29,5 +29,9 @@ function mergeDefaults(objectValue, sourceValue) {
 module.exports = function() {
   var args = _.toArray(arguments);
 
-  return _.merge.apply(null, _.initial(args).concat(_.rest(args).map(_.cloneDeep)).concat(mergeDefaults));
+  return [_.head(args)].concat(_.drop(args)).map(_.cloneDeep).concat(_.head(args)).reverse().reduce((result, object) => {
+    return _.mergeWith(result, object, (objectValue, sourceValue) => {
+      return _.isArray(sourceValue) ? sourceValue : undefined;
+    });
+  });
 };

--- a/package.json
+++ b/package.json
@@ -26,18 +26,18 @@
   },
   "license": "MIT",
   "scripts": {
-    "changelog": "./node_modules/.bin/github-changes -o seegno -r defaults-deep-safe -a --only-pulls --use-commit-body --title 'Changelog' --date-format '/ YYYY-MM-DD'",
-    "test": "NODE_ENV=test ./node_modules/.bin/mocha test/*_test.js --require should --reporter spec"
+    "changelog": "github-changelog-generator -f $npm_package_version > CHANGELOG.md",
+    "test": "mocha test/*_test.js --require should"
   },
   "dependencies": {
-    "lodash": "^3.1.0"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
-    "github-changes": "0.0.16",
-    "mocha": "^2.0.1",
-    "should": "^4.2.1"
+    "@uphold/github-changelog-generator": "^0.7.0",
+    "mocha": "^5.2.0",
+    "should": "^13.2.3"
   },
   "engines": {
-    "node": ">= 0.10"
+    "node": ">=4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/seegno/defaults-deep-safe.git"
+    "url": "https://github.com/ruimarinho/defaults-deep-safe.git"
   },
   "description": "A deep version of _.defaults, safe by default.",
   "keywords": [
@@ -17,12 +17,11 @@
   ],
   "author": {
     "name": "Rui Marinho",
-    "email": "rui.marinho@seegno.com",
-    "url": "https://seegno.com"
+    "email": "rui@uphold.com"
   },
-  "homepage": "https://github.com/seegno/defaults-deep-safe",
+  "homepage": "https://github.com/ruimarinho/defaults-deep-safe",
   "bugs": {
-    "url": "https://github.com/seegno/defaults-deep-safe/issues"
+    "url": "https://github.com/ruimarinho/defaults-deep-safe/issues"
   },
   "license": "MIT",
   "scripts": {

--- a/test/deep-merge_test.js
+++ b/test/deep-merge_test.js
@@ -44,7 +44,7 @@ describe('Deep merge', function() {
     result.should.have.property('foo', 'bar');
     result.bar.should.have.keys('biz');
     result.bar.biz.should.have.keys('net', 'qox');
-    result.should.have.property('bar').with.a.property('biz').which.is.an.Object.with.properties({
+    result.bar.biz.should.have.properties({
       net: 'qux',
       qox: 'fuc'
     });


### PR DESCRIPTION
Update dependencies to their latest version. Includes an update to the new package we use to generate changelogs.

The code for `defaultsDeep()` was significantly changed, copied from @Americas's implementation, in order to keep its behaviour after the major lodash update.